### PR TITLE
Update mimemagic

### DIFF
--- a/file_validators.gemspec
+++ b/file_validators.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activemodel', '>= 3.0'
   s.add_dependency 'mime-types', '>= 1.0'
-  s.add_dependency('mimemagic', '>= 0.3.0')
+  s.add_dependency('mimemagic', '>= 0.4.2')
   s.add_dependency('cocaine', '~> 0.5.5')
 
   s.add_development_dependency 'rake'

--- a/lib/file_validators/version.rb
+++ b/lib/file_validators/version.rb
@@ -1,3 +1,3 @@
 module FileValidators
-  VERSION = '2.0.5'
+  VERSION = '2.0.6'
 end


### PR DESCRIPTION
Mimemagic introduced some breaking changes which had a cascading effect on failed deployments across our repos and other repos on the internet. This fix updates the version so it can still use its MIT licence 